### PR TITLE
Fix potential error from clone-num logic in `DefaultObject.copy`

### DIFF
--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1509,11 +1509,13 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             returns the new clone name on the form keyXX
             """
             key = self.key
-            num = sum(
-                1
-                for obj in self.location.contents
-                if obj.key.startswith(key) and obj.key.lstrip(key).isdigit()
-            )
+            num = 1
+            if self.location:
+                num = max(0, *[
+                    int(obj.key.lstrip(key) or 0)
+                    for obj in self.location.contents
+                    if obj.key.startswith(key)
+                ])+1
             return "%s%03i" % (key, num)
 
         new_key = new_key or find_clone_key()

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1512,9 +1512,9 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             num = 1
             if self.location:
                 num = max(0, *[
-                    int(obj.key.lstrip(key) or 0)
+                    int(obj.key.lstrip(key))
                     for obj in self.location.contents
-                    if obj.key.startswith(key)
+                    if obj.key.startswith(key) and obj.key.lstrip(key).isdigit()
                 ])+1
             return "%s%03i" % (key, num)
 

--- a/evennia/objects/tests.py
+++ b/evennia/objects/tests.py
@@ -395,6 +395,30 @@ class TestObjectManager(BaseEvenniaTest):
         self.assertEqual(self.obj1.attributes.get(key="phrase", category="adventure"), "plugh")
         self.assertEqual(obj2.attributes.get(key="phrase", category="adventure"), "plugh")
 
+    def test_copy_object_clone_key(self):
+        # reset key to avoid overlap with other tests
+        self.obj1.key = "CopyMe"
+        copied = self.obj1.copy()
+        self.assertEqual(copied.key, "CopyMe001")  # original was Obj
+        copied2 = self.obj1.copy()
+        self.assertEqual(copied2.key, "CopyMe002")  # next clone
+        # verify that it increments based on max existing identifier
+        # both for skipped numbers...
+        copied.key = "CopyMe003"
+        copied3 = self.obj1.copy()
+        self.assertEqual(copied3.key, "CopyMe004")
+        copied3.delete()
+        # ...and for duplicate numbers
+        copied.key = "CopyMe001"
+        copied2.key = "CopyMe001"
+        copied3 = self.obj1.copy()
+        self.assertEqual(copied3.key, "CopyMe002")
+
+    def test_copy_object_no_location(self):
+        self.obj1.location = None
+        # we just want to make sure this doesn't error
+        self.assertIsNotNone(self.obj1.copy())
+
 
 class TestContentHandler(BaseEvenniaTest):
     "Test the ContentHandler (obj.contents)"

--- a/evennia/objects/tests.py
+++ b/evennia/objects/tests.py
@@ -399,9 +399,9 @@ class TestObjectManager(BaseEvenniaTest):
         # reset key to avoid overlap with other tests
         self.obj1.key = "CopyMe"
         copied = self.obj1.copy()
-        self.assertEqual(copied.key, "CopyMe001")  # original was Obj
+        self.assertEqual(copied.key, "CopyMe001")
         copied2 = self.obj1.copy()
-        self.assertEqual(copied2.key, "CopyMe002")  # next clone
+        self.assertEqual(copied2.key, "CopyMe002")
         # verify that it increments based on max existing identifier
         # both for skipped numbers...
         copied.key = "CopyMe003"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This adds handling for the situation where the object being copied has no location, and also makes it so that the produced key follows the rules described in the docstring (appends the next available integer suffix from the largest integer suffix present in the location).

#### Motivation for adding to Evennia
Bug fixing

#### Other info (issues closed, discussion etc)
Unit tests included :tm: 